### PR TITLE
Fix department dropdown React child error

### DIFF
--- a/client/src/pages/surveys/SurveyCreate.js
+++ b/client/src/pages/surveys/SurveyCreate.js
@@ -245,11 +245,16 @@ const SurveyCreate = () => {
                         Loading departments...
                       </MenuItem>
                     ) : (
-                      departments.map((dept) => (
-                        <MenuItem key={dept} value={dept}>
-                          {dept}
-                        </MenuItem>
-                      ))
+                      [
+                        <MenuItem key="all" value="All Departments">
+                          All Departments
+                        </MenuItem>,
+                        ...departments.map((dept) => (
+                          <MenuItem key={dept._id} value={dept.name}>
+                            {dept.name}
+                          </MenuItem>
+                        ))
+                      ]
                     )}
                   </Select>
                   {formik.touched.department && formik.errors.department && (


### PR DESCRIPTION
- Updated department dropdown to handle department objects properly
- Use dept._id as key and dept.name as value and display text
- Added 'All Departments' option at the top of the dropdown
- Fixed 'Objects are not valid as a React child' error
- Department filtering now works with department names correctly

The dropdown now properly renders department names instead of trying to render entire objects.