### PR TITLE
Simplify survey creation to use user IDs directly

### DIFF
--- a/client/src/pages/surveys/SurveyCreate.js
+++ b/client/src/pages/surveys/SurveyCreate.js
@@ -7,18 +7,13 @@ import {
   TextField,
   Button,
   Grid,
-  FormControl,
-  InputLabel,
-  Select,
-  MenuItem,
-  FormHelperText,
   CircularProgress,
   Divider,
   Autocomplete,
   Chip
 } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
-import { surveyApi, employeeApi, departmentApi } from '../../services/api';
+import { surveyApi, employeeApi } from '../../services/api';
 import { toast } from 'react-toastify';
 import { useFormik } from 'formik';
 import * as Yup from 'yup';
@@ -28,11 +23,8 @@ import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 
 const SurveyCreate = () => {
   const [loading, setLoading] = useState(false);
-  const [departments, setDepartments] = useState([]);
-  const [employees, setEmployees] = useState([]);
-  const [filteredEmployees, setFilteredEmployees] = useState([]);
-  const [loadingDepartments, setLoadingDepartments] = useState(false);
-  const [loadingEmployees, setLoadingEmployees] = useState(false);
+  const [users, setUsers] = useState([]);
+  const [loadingUsers, setLoadingUsers] = useState(false);
   const navigate = useNavigate();
 
   // Form validation schema
@@ -47,14 +39,9 @@ const SurveyCreate = () => {
       .required('Duration is required')
       .positive('Duration must be positive')
       .integer('Duration must be a whole number'),
-    department: Yup.string()
-      .required('Department is required'),
-    employees: Yup.array()
-      .when('department', {
-        is: 'All Departments',
-        then: (schema) => schema,
-        otherwise: (schema) => schema.min(1, 'Select at least one employee')
-      })
+    targetUsers: Yup.array()
+      .min(1, 'Select at least one user for the survey')
+      .required('Target users are required')
   });
 
   // Formik setup
@@ -63,8 +50,7 @@ const SurveyCreate = () => {
       name: '',
       publishDate: null,
       durationDays: 7,
-      department: '',
-      employees: []
+      targetUsers: []
     },
     validationSchema: validationSchema,
     onSubmit: async (values) => {
@@ -75,7 +61,7 @@ const SurveyCreate = () => {
         const surveyData = {
           ...values,
           publishDate: values.publishDate ? values.publishDate.toISOString() : null,
-          employees: values.employees.map(emp => emp.id)
+          targetUsers: values.targetUsers.map(user => user.id)
         };
 
         const result = await surveyApi.createSurvey(surveyData);
@@ -94,63 +80,35 @@ const SurveyCreate = () => {
     }
   });
 
-  // Fetch departments function
-  const fetchDepartments = async () => {
-    setLoadingDepartments(true);
+  // Fetch users function
+  const fetchUsers = async () => {
+    setLoadingUsers(true);
     try {
-      const result = await departmentApi.getDepartments();
+      const result = await employeeApi.getEmployees();
       if (result.success) {
-        setDepartments(result.data);
-      } else {
-        toast.error(result.message || 'Failed to fetch departments');
-      }
-    } catch (error) {
-      console.error('Error fetching departments:', error);
-      toast.error('Failed to fetch departments');
-    } finally {
-      setLoadingDepartments(false);
-    }
-  };
-
-  // Fetch employees function
-  const fetchEmployees = async (department = null) => {
-    setLoadingEmployees(true);
-    try {
-      const params = department && department !== 'All Departments' ? { department } : {};
-      const result = await employeeApi.getEmployees(params);
-      if (result.success) {
-        const employeeData = result.data.map(emp => ({
-          id: emp._id,
-          name: emp.name,
-          email: emp.email,
-          department: emp.department
+        const userData = result.data.map(user => ({
+          id: user._id,
+          name: user.name,
+          email: user.email,
+          department: user.department?.name || 'No Department',
+          role: user.role
         }));
-        setEmployees(employeeData);
-        setFilteredEmployees(employeeData);
+        setUsers(userData);
       } else {
-        toast.error(result.message || 'Failed to fetch employees');
+        toast.error(result.message || 'Failed to fetch users');
       }
     } catch (error) {
-      console.error('Error fetching employees:', error);
-      toast.error('Failed to fetch employees');
+      console.error('Error fetching users:', error);
+      toast.error('Failed to fetch users');
     } finally {
-      setLoadingEmployees(false);
+      setLoadingUsers(false);
     }
   };
 
-  // Fetch departments on component mount
+  // Fetch users on component mount
   useEffect(() => {
-    fetchDepartments();
+    fetchUsers();
   }, []);
-
-  // Fetch employees when department changes
-  useEffect(() => {
-    if (formik.values.department && formik.values.department !== 'All Departments') {
-      fetchEmployees(formik.values.department);
-    } else if (formik.values.department === 'All Departments') {
-      fetchEmployees();
-    }
-  }, [formik.values.department]);
 
   const handleCancel = () => {
     navigate('/surveys');
@@ -220,92 +178,46 @@ const SurveyCreate = () => {
               </Grid>
 
               <Grid item xs={12}>
-                <FormControl 
-                  fullWidth
-                  error={formik.touched.department && Boolean(formik.errors.department)}
-                >
-                  <InputLabel id="department-label">Target Department</InputLabel>
-                  <Select
-                    labelId="department-label"
-                    id="department"
-                    name="department"
-                    value={formik.values.department}
-                    label="Target Department"
-                    onChange={(e) => {
-                      formik.setFieldValue('department', e.target.value);
-                      // Reset employees when department changes
-                      formik.setFieldValue('employees', []);
-                    }}
-                    onBlur={formik.handleBlur}
-                    disabled={loadingDepartments}
-                  >
-                    {loadingDepartments ? (
-                      <MenuItem disabled>
-                        <CircularProgress size={20} sx={{ mr: 1 }} />
-                        Loading departments...
-                      </MenuItem>
-                    ) : (
-                      [
-                        <MenuItem key="all" value="All Departments">
-                          All Departments
-                        </MenuItem>,
-                        ...departments.map((dept) => (
-                          <MenuItem key={dept._id} value={dept.name}>
-                            {dept.name}
-                          </MenuItem>
-                        ))
-                      ]
-                    )}
-                  </Select>
-                  {formik.touched.department && formik.errors.department && (
-                    <FormHelperText>{formik.errors.department}</FormHelperText>
-                  )}
-                </FormControl>
-              </Grid>
-
-              {formik.values.department && formik.values.department !== 'All Departments' && (
-                <Grid item xs={12}>
-                  <Autocomplete
-                    multiple
-                    id="employees"
-                    options={filteredEmployees}
-                    getOptionLabel={(option) => `${option.name} (${option.email})`}
-                    value={formik.values.employees}
-                    onChange={(event, newValue) => {
-                      formik.setFieldValue('employees', newValue);
-                    }}
-                    loading={loadingEmployees}
-                    disabled={loadingEmployees}
-                    renderTags={(value, getTagProps) =>
-                      value.map((option, index) => (
-                        <Chip
-                          label={option.name}
-                          {...getTagProps({ index })}
-                          key={option.id}
-                        />
-                      ))
-                    }
-                    renderInput={(params) => (
-                      <TextField
-                        {...params}
-                        label="Target Employees"
-                        placeholder={loadingEmployees ? "Loading employees..." : "Select employees"}
-                        error={formik.touched.employees && Boolean(formik.errors.employees)}
-                        helperText={formik.touched.employees && formik.errors.employees}
-                        InputProps={{
-                          ...params.InputProps,
-                          endAdornment: (
-                            <>
-                              {loadingEmployees ? <CircularProgress color="inherit" size={20} /> : null}
-                              {params.InputProps.endAdornment}
-                            </>
-                          ),
-                        }}
+                <Autocomplete
+                  multiple
+                  id="targetUsers"
+                  options={users}
+                  getOptionLabel={(option) => `${option.name} (${option.email}) - ${option.department}`}
+                  value={formik.values.targetUsers}
+                  onChange={(event, newValue) => {
+                    formik.setFieldValue('targetUsers', newValue);
+                  }}
+                  loading={loadingUsers}
+                  disabled={loadingUsers}
+                  renderTags={(value, getTagProps) =>
+                    value.map((option, index) => (
+                      <Chip
+                        label={`${option.name} - ${option.department}`}
+                        {...getTagProps({ index })}
+                        key={option.id}
                       />
-                    )}
-                  />
-                </Grid>
-              )}
+                    ))
+                  }
+                  renderInput={(params) => (
+                    <TextField
+                      {...params}
+                      label="Target Users"
+                      placeholder={loadingUsers ? "Loading users..." : "Select users for the survey"}
+                      error={formik.touched.targetUsers && Boolean(formik.errors.targetUsers)}
+                      helperText={formik.touched.targetUsers && formik.errors.targetUsers}
+                      InputProps={{
+                        ...params.InputProps,
+                        endAdornment: (
+                          <>
+                            {loadingUsers ? <CircularProgress color="inherit" size={20} /> : null}
+                            {params.InputProps.endAdornment}
+                          </>
+                        ),
+                      }}
+                    />
+                  )}
+                />
+              </Grid>
             </Grid>
 
             <Divider sx={{ my: 3 }} />


### PR DESCRIPTION
- Removed department filtering complexity
- Updated form to work with targetUsers instead of department + employees
- Simplified validation schema to only require targetUsers selection
- Updated state management to only handle users, not departments/employees
- Users can now directly select target users by ID without department filtering
- Shows user name, email, and department in selection dropdown
- Cleaner, more direct approach for survey target selection

This eliminates the department filtering step and works directly with user IDs as requested.