### PR TITLE
Fix consent email sending endpoint

### DIFF
--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -338,9 +338,8 @@ export const consentApi = {
 
   // Send consent emails
   sendConsentEmails: async (surveyId) => {
-    debugger
     try {
-      const response = await axios.post(`/api/surveys/${surveyId}/consent/send-emails`);
+      const response = await axios.post(`/api/surveys/${surveyId}/generate-consent`);
       return { success: true, data: response.data.data };
     } catch (error) {
       console.error(`Error sending consent emails for survey ${surveyId}:`, error);


### PR DESCRIPTION
- Fixed sendConsentEmails API function to use correct endpoint
- Changed from /api/surveys/:surveyId/consent/send-emails to /api/surveys/:surveyId/generate-consent
- The generate-consent endpoint already handles both creating consent records and sending emails
- Removed debugger statement from the function
- This fixes the 'Please provide consent value' error when clicking Send Consent Emails