### PR TITLE
Update email configuration with Paisalo SMTP server settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,13 +21,13 @@ EMAIL_FROM=Survey Management System <your-email@gmail.com>
 # EMAIL_PASSWORD=your-password
 # EMAIL_FROM=Survey Management System <your-email@outlook.com>
 
-# Option 3: Custom SMTP Server
-# EMAIL_HOST=smtp.your-domain.com
-# EMAIL_PORT=587
-# EMAIL_SECURE=false
-# EMAIL_USERNAME=your-email@your-domain.com
+# Option 3: Custom SMTP Server (Example: Paisalo)
+# EMAIL_HOST=email.paisalo.in
+# EMAIL_PORT=465
+# EMAIL_SECURE=true
+# EMAIL_USERNAME=noreply1@paisalo.in
 # EMAIL_PASSWORD=your-password
-# EMAIL_FROM=Survey Management System <your-email@your-domain.com>
+# EMAIL_FROM=Survey Management System <noreply1@paisalo.in>
 
 # JWT Configuration
 JWT_SECRET=your-super-secret-jwt-key-here

--- a/EMAIL_SETUP.md
+++ b/EMAIL_SETUP.md
@@ -39,16 +39,21 @@ EMAIL_PASSWORD=your-password
 EMAIL_FROM=Survey Management System <your-email@outlook.com>
 ```
 
-### Option 3: Custom SMTP Server
+### Option 3: Custom SMTP Server (Example: Paisalo)
 
 ```env
-EMAIL_HOST=smtp.your-domain.com
-EMAIL_PORT=587
-EMAIL_SECURE=false
-EMAIL_USERNAME=your-email@your-domain.com
+EMAIL_HOST=email.paisalo.in
+EMAIL_PORT=465
+EMAIL_SECURE=true
+EMAIL_USERNAME=noreply1@paisalo.in
 EMAIL_PASSWORD=your-password
-EMAIL_FROM=Survey Management System <your-email@your-domain.com>
+EMAIL_FROM=Survey Management System <noreply1@paisalo.in>
 ```
+
+**Note:** For Paisalo SMTP server:
+- Use **port 465** with **SSL enabled** (`EMAIL_SECURE=true`)
+- This corresponds to `SecureSocketOptions.SslOnConnect` in C# code
+- The server requires implicit SSL connection
 
 ## Testing Email Configuration
 


### PR DESCRIPTION
- Updated .env.example with Paisalo SMTP server configuration (email.paisalo.in:465)
- Added specific notes for Paisalo SMTP setup in EMAIL_SETUP.md
- Configured for port 465 with SSL enabled (EMAIL_SECURE=true)
- Matches the C# SmtpClient configuration with SecureSocketOptions.SslOnConnect
- Uses noreply1@paisalo.in as the sender email address

This provides the correct SMTP configuration for the Paisalo email server.