### PR TITLE
Make survey taking publicly accessible

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -122,7 +122,8 @@ function App() {
         <Route path="/register" element={<Register />} />
         <Route path="/consent/:token" element={<ConsentForm />} />
         
-        {/* Anonymous Survey Route - No authentication required */}
+        {/* Public Survey Routes - No authentication required */}
+        <Route path="/surveys/:id/take" element={<TakeSurvey />} />
         <Route path="/survey/:token" element={<AnonymousSurveyAttempt />} />
 
         {/* Protected Routes */}
@@ -156,7 +157,6 @@ function App() {
             }
           />
           <Route path="surveys/:id" element={<SurveyDetail />} />
-          <Route path="surveys/:id/take" element={<TakeSurvey />} />
 
           {/* Question Routes */}
           <Route

--- a/client/src/pages/survey/TakeSurvey.js
+++ b/client/src/pages/survey/TakeSurvey.js
@@ -195,10 +195,8 @@ const TakeSurvey = () => {
 
       setSuccess('Survey submitted successfully! Thank you for your participation.');
       
-      // Redirect after a delay
-      setTimeout(() => {
-        navigate('/dashboard');
-      }, 3000);
+      // For public access, just show success message without redirect
+      // Users can close the tab or navigate away manually
 
     } catch (err) {
       setError('Failed to submit survey. Please try again.');


### PR DESCRIPTION
- Move survey taking route outside protected routes in App.js
- Remove duplicate protected route for surveys/:id/take
- Update TakeSurvey component to not redirect to dashboard after submission
- Enable public access to survey forms without authentication